### PR TITLE
docs: adds Dubai how-to notebook

### DIFF
--- a/nbs/tutorials/dubai.ipynb
+++ b/nbs/tutorials/dubai.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dubai\n",
+    "Quantum-accurate bond inference and partial charge calculations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0) Setup\n",
+    "This is where we prepare the tengu client, directories, and input data we'll be working with."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0.0) Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import requests\n",
+    "import tengu\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0.1) Credentials\n",
+    "Add a API URl and a access token to authenticate to the Tengu API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set our token - ensure you have exported TENGU_TOKEN in your shell; or just replace the os.getenv statement with your token\n",
+    "TOKEN = os.getenv(\"TENGU_TOKEN\")\n",
+    "\n",
+    "# You might have a custom deployment url, by default it will use https://tengu.qdx.ai\n",
+    "TENGU_URL = os.getenv(\"TENGU_URL\") or \"https://tengu.qdx.ai\"\n",
+    "\n",
+    "# If you have environment variables set, they will be automatically used by the Tengu client, so you can\n",
+    "# skip this step in your future work with the Tengu client. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 0.2) Configuration\n",
+    "Let's set some global variables that define our project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define our project information\n",
+    "DESCRIPTION = \"tengu-py demo notebook\"\n",
+    "TAGS = [\"tengu-py\", \"demo\", \"dubai\", \"convert\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0.3) Build your tengu client\n",
+    "In this step, we create a Tengu client that serves as the Python interface for the individual cheminformatics modules within the Tengu API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get our client, for calling modules and using the tengu API.\n",
+    "# Note, access_token and url are optional if you have exported the env variables TENGU_TOKEN and TENGU_URL.\n",
+    "# Workspace sets the location where we will store our session history file and module lock file.\n",
+    "# By using the `build_provider_with_functions` method, we will also build helper functions calling each module.\n",
+    "\n",
+    "# Delete and recreate the working directory if it exists\n",
+    "WORK_DIR = Path.home() / \"qdx\" / \"cairo-tengu-py-demo\"\n",
+    "\n",
+    "if not WORK_DIR.exists():\n",
+    "    Path(WORK_DIR).mkdir(parents=True)  \n",
+    "    client = await tengu.build_provider_with_functions(\n",
+    "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
+    "    )\n",
+    "else:\n",
+    "    client = await tengu.build_provider_with_functions(\n",
+    "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
+    "    )\n",
+    "    await client.nuke()\n",
+    "    Path(WORK_DIR).mkdir(parents=True)\n",
+    "    client = await tengu.build_provider_with_functions(\n",
+    "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
+    "    )\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0.4) Download Aspirin from PubChem and convert to QDXF format\n",
+    "QDXF is the central molecule format of the Tengu API, so before we use the Dubai module to infer connectivity (bonds) for our molecule, we must convert our SDF file to QDXF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert aspirin to a QDXF file so we can use it for this demo\n",
+    "SMILES_STRING = \"CC(=O)OC1=CC=CC=C1C(=O)O\"\n",
+    "SDF_LINK = f\"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/smiles/{SMILES_STRING}/record/SDF?record_type=3d\"\n",
+    "\n",
+    "file_path = f'{WORK_DIR}/aspirin.sdf'\n",
+    "with open(file_path, 'wb') as f:\n",
+    "    f.write(requests.get(SDF_LINK).content)\n",
+    "\n",
+    "# We need to specify storage > file size to ensure that we have allocated enough resources for the convert module\n",
+    "(ligand,) = await client.convert(\"SDF\", Path(file_path), resources={\"storage\": 5000})\n",
+    "await ligand.get()\n",
+    "\n",
+    "ligand = await ligand.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remove connectivity, as we will be perceiving bonds (quantum-accurately) using Dubai in the next step\n",
+    "EXPECTED_CONNECTIVITY = ligand[0]['topology']['connectivity']\n",
+    "\n",
+    "ligand = ligand[0]\n",
+    "# Remove connectivity as dubai will perceive the bonds for us\n",
+    "del ligand['topology']['connectivity']\n",
+    "\n",
+    "# Use a fragment multiplicity of 1.\n",
+    "ligand['topology']['fragment_multiplicities'] = [1]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.0) Set Dubai module specific configuration\n",
+    "In this stage, we set configuration for the Dubai module, as well as saving our QDXF Aspirin to disk, as the Dubai module needs the file itself.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DUBAI_RESOURCES = {\n",
+    "    \"gpus\": 1,\n",
+    "    \"storage\": 1024_000,\n",
+    "    \"walltime\": 60,\n",
+    "}\n",
+    "TEMP_FILEPATH = Path(f'{WORK_DIR}/temp/aspirin.qdxf.json')\n",
+    "\n",
+    "# Create the temp directory, so we can save our temporary QDXF file later.\n",
+    "Path(f'{WORK_DIR}/temp').mkdir(parents=True)  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.1) Run Dubai\n",
+    "Finally, we run Dubai to perform quantum-accurate bond inference, as well the calculation of partial charges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 140,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json.dump(ligand, open(TEMP_FILEPATH, 'w'))\n",
+    "\n",
+    "(ligand_with_bonds,) = await client.dubai(TEMP_FILEPATH, resources=DUBAI_RESOURCES)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pprint import pprint\n",
+    "output_ligand = (await ligand_with_bonds.get())\n",
+    "\n",
+    "for expected_bond, outputed_bond in zip(EXPECTED_CONNECTIVITY, output_ligand['topology']['connectivity']):\n",
+    "    # Check start atoms are the same\n",
+    "    assert expected_bond[0] == outputed_bond[0]\n",
+    "    # Check ending atoms are the same\n",
+    "    assert expected_bond[1] == outputed_bond[1]\n",
+    "    # NB: we don't check the third item of the bond -- the bond type, as Dubai accurately outputs ring bonds as \n",
+    "    # a specific 'RINGBOND' type, whereas SDF aspirin was interleaving single and double bonds."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nbs/tutorials/ligand_bond_inference_and_partial_charge_calculation.ipynb
+++ b/nbs/tutorials/ligand_bond_inference_and_partial_charge_calculation.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,11 +84,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "WORK_DIR = Path.home() / \"qdx\" / \"cairo-tengu-py-demo\"\n",
+    "WORK_DIR = Path.home() / \"qdx\" / \"dubai-tengu-py-demo\"\n",
     "\n",
     "# Get our client, for calling modules and using the tengu \n",
     "# Remove old workspace if it already exists\n",
@@ -105,8 +105,7 @@
     "    Path(WORK_DIR).mkdir(parents=True)\n",
     "    client = await tengu.build_provider_with_functions(\n",
     "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
-    "    )\n",
-    "\n"
+    "    )"
    ]
   },
   {
@@ -118,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +165,7 @@
     "del ligand['topology']['connectivity']\n",
     "\n",
     "# Use a fragment multiplicity of 1.\n",
-    "ligand['topology']['fragment_multiplicities'] = [1]\n"
+    "ligand['topology']['fragment_multiplicities'] = [1]"
    ]
   },
   {
@@ -179,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +190,7 @@
     "TEMP_FILEPATH = Path(f'{WORK_DIR}/temp/aspirin.qdxf.json')\n",
     "\n",
     "# Create the temp directory, so we can save our temporary QDXF file later.\n",
-    "Path(f'{WORK_DIR}/temp').mkdir(parents=True)  \n"
+    "Path(f'{WORK_DIR}/temp').mkdir(parents=True)  "
    ]
   },
   {
@@ -204,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/nbs/tutorials/ligand_bond_inference_and_partial_charge_calculation.ipynb
+++ b/nbs/tutorials/ligand_bond_inference_and_partial_charge_calculation.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,19 +60,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 0.2) Configuration\n",
+    "## 0.2) Configuration\n",
     "Let's set some global variables that define our project."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define our project information\n",
     "DESCRIPTION = \"quantum-bond-inference-notebook\"\n",
-    "TAGS = [\"tengu-py\", \"dubai\", \"convert\"]"
+    "TAGS = [\"tengu-py\", \"dubai\", \"convert\"]\n",
+    "WORK_DIR = Path.home() / \"qdx\" / \"dubai-tengu-py-demo\""
    ]
   },
   {
@@ -84,28 +84,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
-    "WORK_DIR = Path.home() / \"qdx\" / \"dubai-tengu-py-demo\"\n",
+    "#|hide\n",
+    "client = tengu.Provider(workspace=WORK_DIR,access_token=TOKEN, url=TENGU_URL)\n",
+    "await client.nuke()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(WORK_DIR, exist_ok=True)\n",
     "\n",
-    "# Get our client, for calling modules and using the tengu \n",
-    "# Remove old workspace if it already exists\n",
-    "if not WORK_DIR.exists():\n",
-    "    Path(WORK_DIR).mkdir(parents=True)  \n",
-    "    client = await tengu.build_provider_with_functions(\n",
-    "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
-    "    )\n",
-    "else:\n",
-    "    client = await tengu.build_provider_with_functions(\n",
-    "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
-    "    )\n",
-    "    await client.nuke()\n",
-    "    Path(WORK_DIR).mkdir(parents=True)\n",
-    "    client = await tengu.build_provider_with_functions(\n",
-    "        access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
-    "    )"
+    "client = await tengu.build_provider_with_functions(\n",
+    "    access_token=TOKEN, url=TENGU_URL, workspace=WORK_DIR, batch_tags=TAGS\n",
+    ")"
    ]
   },
   {
@@ -117,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,19 +150,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0.6 ) Remove connectivity\n",
+    "We remove connectivity, as we will be perceiving bonds (quantum-accurately) using Dubai in the next step."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Remove connectivity, as we will be perceiving bonds (quantum-accurately) using Dubai in the next step\n",
     "EXPECTED_CONNECTIVITY = ligand[0]['topology']['connectivity']\n",
-    "\n",
     "ligand = ligand[0]\n",
-    "# Remove connectivity as dubai will perceive the bonds for us\n",
     "del ligand['topology']['connectivity']\n",
     "\n",
-    "# Use a fragment multiplicity of 1.\n",
     "ligand['topology']['fragment_multiplicities'] = [1]"
    ]
   },
@@ -178,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,10 +189,8 @@
     "    \"storage\": 1024_000,\n",
     "    \"walltime\": 60,\n",
     "}\n",
-    "TEMP_FILEPATH = Path(f'{WORK_DIR}/temp/aspirin.qdxf.json')\n",
-    "\n",
-    "# Create the temp directory, so we can save our temporary QDXF file later.\n",
-    "Path(f'{WORK_DIR}/temp').mkdir(parents=True)  "
+    "LIGAND_FILEPATH = Path(f'{WORK_DIR}/aspirin.qdxf.json')\n",
+    "json.dump(ligand, open(LIGAND_FILEPATH, 'w'))"
    ]
   },
   {
@@ -203,28 +203,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
-    "json.dump(ligand, open(TEMP_FILEPATH, 'w'))\n",
-    "\n",
-    "(ligand_with_bonds,) = await client.dubai(TEMP_FILEPATH, resources=DUBAI_RESOURCES)"
+    "(ligand_with_bonds,) = await client.dubai(LIGAND_FILEPATH, resources=DUBAI_RESOURCES)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_ligand = (await ligand_with_bonds.get())\n",
+    "output_ligand = await ligand_with_bonds.get()\n",
     "\n",
-    "for expected_bond, outputed_bond in zip(EXPECTED_CONNECTIVITY, output_ligand['topology']['connectivity']):\n",
+    "for expected_bond, outputted_bond in zip(EXPECTED_CONNECTIVITY, output_ligand['topology']['connectivity']):\n",
     "    # Check start atoms are the same\n",
-    "    assert expected_bond[0] == outputed_bond[0]\n",
+    "    assert expected_bond[0] == outputted_bond[0]\n",
     "    # Check ending atoms are the same\n",
-    "    assert expected_bond[1] == outputed_bond[1]\n",
+    "    assert expected_bond[1] == outputted_bond[1]\n",
     "    # NB: we don't check the third item of the bond -- the bond type. This is because Dubai accurately outputs ring bonds as \n",
     "    # a specific 'RINGBOND' type, whereas SDF aspirin was interleaving single and double bonds."
    ]

--- a/nbs/tutorials/ligand_bond_inference_and_partial_charge_calculation.ipynb
+++ b/nbs/tutorials/ligand_bond_inference_and_partial_charge_calculation.ipynb
@@ -4,8 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dubai\n",
-    "Quantum-accurate bond inference and partial charge calculations."
+    "# Dubai - Quantum accurate bond inference and partial charge calculations \n",
+    "\n",
+    "This notebook will work us through getting quantum-accurate bond inference and Mulliken partial charge calculations for a SMILES string retrieved from PubChem."
    ]
   },
   {
@@ -13,7 +14,7 @@
    "metadata": {},
    "source": [
     "## 0) Setup\n",
-    "This is where we prepare the tengu client, directories, and input data we'll be working with."
+    "See [Quickstart](../index.ipynb#imports) for more details on the setup."
    ]
   },
   {
@@ -25,39 +26,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "import json\n",
+    "from pathlib import Path\n",
+    "\n",
     "import requests\n",
-    "import tengu\n",
-    "from pathlib import Path"
+    "import tengu"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 0.1) Credentials\n",
-    "Add a API URl and a access token to authenticate to the Tengu API."
+    "## 0.1) Credentials\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set our token - ensure you have exported TENGU_TOKEN in your shell; or just replace the os.getenv statement with your token\n",
     "TOKEN = os.getenv(\"TENGU_TOKEN\")\n",
-    "\n",
     "# You might have a custom deployment url, by default it will use https://tengu.qdx.ai\n",
-    "TENGU_URL = os.getenv(\"TENGU_URL\") or \"https://tengu.qdx.ai\"\n",
-    "\n",
-    "# If you have environment variables set, they will be automatically used by the Tengu client, so you can\n",
-    "# skip this step in your future work with the Tengu client. "
+    "TENGU_URL = os.getenv(\"TENGU_URL\") or \"https://tengu.qdx.ai\""
    ]
   },
   {
@@ -70,37 +66,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Define our project information\n",
-    "DESCRIPTION = \"tengu-py demo notebook\"\n",
-    "TAGS = [\"tengu-py\", \"demo\", \"dubai\", \"convert\"]"
+    "DESCRIPTION = \"quantum-bond-inference-notebook\"\n",
+    "TAGS = [\"tengu-py\", \"dubai\", \"convert\"]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 0.3) Build your tengu client\n",
-    "In this step, we create a Tengu client that serves as the Python interface for the individual cheminformatics modules within the Tengu API."
+    "## 0.3) Build your tengu client"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get our client, for calling modules and using the tengu API.\n",
-    "# Note, access_token and url are optional if you have exported the env variables TENGU_TOKEN and TENGU_URL.\n",
-    "# Workspace sets the location where we will store our session history file and module lock file.\n",
-    "# By using the `build_provider_with_functions` method, we will also build helper functions calling each module.\n",
-    "\n",
-    "# Delete and recreate the working directory if it exists\n",
     "WORK_DIR = Path.home() / \"qdx\" / \"cairo-tengu-py-demo\"\n",
     "\n",
+    "# Get our client, for calling modules and using the tengu \n",
+    "# Remove old workspace if it already exists\n",
     "if not WORK_DIR.exists():\n",
     "    Path(WORK_DIR).mkdir(parents=True)  \n",
     "    client = await tengu.build_provider_with_functions(\n",
@@ -122,13 +113,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 0.4) Download Aspirin from PubChem and convert to QDXF format\n",
-    "QDXF is the central molecule format of the Tengu API, so before we use the Dubai module to infer connectivity (bonds) for our molecule, we must convert our SDF file to QDXF."
+    "## 0.4) Download Aspirin SDF from PubChem"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,8 +128,23 @@
     "\n",
     "file_path = f'{WORK_DIR}/aspirin.sdf'\n",
     "with open(file_path, 'wb') as f:\n",
-    "    f.write(requests.get(SDF_LINK).content)\n",
-    "\n",
+    "    f.write(requests.get(SDF_LINK).content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0.5) Convert SDF file to QDXF format\n",
+    "QDXF is the central molecule format of the Tengu API, so before we use the Dubai module to infer connectivity (bonds) for our molecule, we must convert our SDF file to QDXF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# We need to specify storage > file size to ensure that we have allocated enough resources for the convert module\n",
     "(ligand,) = await client.convert(\"SDF\", Path(file_path), resources={\"storage\": 5000})\n",
     "await ligand.get()\n",
@@ -149,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,12 +199,12 @@
    "metadata": {},
    "source": [
     "## 1.1) Run Dubai\n",
-    "Finally, we run Dubai to perform quantum-accurate bond inference, as well the calculation of partial charges."
+    "Finally, we run Dubai to perform quantum-accurate bond inference, as well the calculation of Mulliken partial charges."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,11 +215,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pprint import pprint\n",
     "output_ligand = (await ligand_with_bonds.get())\n",
     "\n",
     "for expected_bond, outputed_bond in zip(EXPECTED_CONNECTIVITY, output_ligand['topology']['connectivity']):\n",
@@ -222,7 +226,7 @@
     "    assert expected_bond[0] == outputed_bond[0]\n",
     "    # Check ending atoms are the same\n",
     "    assert expected_bond[1] == outputed_bond[1]\n",
-    "    # NB: we don't check the third item of the bond -- the bond type, as Dubai accurately outputs ring bonds as \n",
+    "    # NB: we don't check the third item of the bond -- the bond type. This is because Dubai accurately outputs ring bonds as \n",
     "    # a specific 'RINGBOND' type, whereas SDF aspirin was interleaving single and double bonds."
    ]
   }


### PR DESCRIPTION
This PR adds a how-to guide notebook for the dubai module.
It is part of a series of notebooks that are brief cookbooks for tengu-py modules.


It should be usable and tractable for a computational chemist, so should be evaluated in that context.